### PR TITLE
Refactor/15 pre commit 분리

### DIFF
--- a/.github/hooks/commit-msg
+++ b/.github/hooks/commit-msg
@@ -4,7 +4,7 @@
 msg_file="$1"
 commit_msg="$(<"$msg_file")"
 
-regex="^(feat|fix|chore|docs|style|refactor|test|perf|ci|build|revert) *\([[:space:]]*#[[:space:]]*[0-9]+[[:space:]]*\) *: .+$"
+regex="^(feat|fix|chore|docs|style|refactor|test|perf|ci|build|revert) \\( #[0-9]+ \\) : .+$"
 
 if [[ ! $commit_msg =~ $regex ]]; then
   echo "❌ 메시지 형식 에러: 타입 ( #이슈 ) : 설명"

--- a/.github/hooks/commit-msg
+++ b/.github/hooks/commit-msg
@@ -4,7 +4,7 @@
 msg_file="$1"
 commit_msg="$(<"$msg_file")"
 
-regex='^(feat|fix|chore|docs|style|refactor|test|perf|ci|build|revert) \( \#\d+ \) : .+$'
+regex="^(feat|fix|chore|docs|style|refactor|test|perf|ci|build|revert) *\([[:space:]]*#[[:space:]]*[0-9]+[[:space:]]*\) *: .+$"
 
 if [[ ! $commit_msg =~ $regex ]]; then
   echo "❌ 메시지 형식 에러: 타입 ( #이슈 ) : 설명"

--- a/.github/hooks/commit-msg
+++ b/.github/hooks/commit-msg
@@ -1,0 +1,14 @@
+#!/bin/bash
+# .git/hooks/commit-msg
+
+msg_file="$1"
+commit_msg="$(<"$msg_file")"
+
+regex='^(feat|fix|chore|docs|style|refactor|test|perf|ci|build|revert) \( \#\d+ \) : .+$'
+
+if [[ ! $commit_msg =~ $regex ]]; then
+  echo "❌ 메시지 형식 에러: 타입 ( #이슈 ) : 설명"
+  exit 1
+fi
+
+echo "✅ 커밋 메시지 형식 OK"

--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,28 +1,11 @@
 #!/bin/bash
+# .git/hooks/pre-commit
 
-# Git 디렉토리 위치
-git_dir=$(git rev-parse --git-dir 2>/dev/null) || { echo "❌ Git 저장소만 지원한다."; exit 1; }
+echo "🔨 Gradle 빌드 검증…"
 
-# 방금 작성된 커밋 메시지 읽기
-commit_msg="$(< "$git_dir/COMMIT_EDITMSG")"
-
-# 메시지 패턴 정의
-regex="^(feat|fix|chore|docs|style|refactor|test|perf|ci|build|revert) *\([[:space:]]*#[[:space:]]*[0-9]+[[:space:]]*\) *: .+$"
-
-if [[ "$commit_msg" =~ $regex ]]; then
-  echo "✅ 커밋 메시지 형식이 올바릅니다."
-else
-  echo "❌ 커밋 메시지 형식이 잘못되었습니다."
-  echo "   형식: 타입(#이슈번호) : 설명"
-  exit 1
-fi
-
-# 기존에 하던 Gradle 빌드 검증도 이어서 실행
-echo "Gradle 빌드 검증 시작..."
 if ! ./gradlew clean build --no-daemon; then
-  echo "❌ 빌드 실패! 커밋 중단."
+  echo "❌ 빌드 실패—커밋 중단"
   exit 1
-else
-  echo "✅ 빌드 성공! 커밋 계속."
-  exit 0
 fi
+
+echo "✅ 빌드 성공"


### PR DESCRIPTION
# 🚧 작업 상세
- 기존 `pre-commit`에 있던 빌드 검증 로직과 커밋 메시지 검증 로직을 `pre-commit` 파일과 `commit-msg` 파일로 분리하였습니다.
- `commit-msg`의 정규식을 커밋 메시지 타입에 맞게 수정하였습니다.
## 📷 첨부
`pre-commit`
<img width="396" alt="image" src="https://github.com/user-attachments/assets/ae056ee4-cd0e-4d7c-8642-4ad4c85faba2" />

`commit-msg`
<img width="740" alt="image" src="https://github.com/user-attachments/assets/d11d6cb9-5293-435b-b054-231b3414bf9d" />

