### PR TITLE
refactor ( #55 ) : SecurityConfig requestMatchers 순서 수정

### DIFF
--- a/casper-application-infrastructure/src/main/kotlin/hs/kr/entrydsm/application/global/config/SecurityConfig.kt
+++ b/casper-application-infrastructure/src/main/kotlin/hs/kr/entrydsm/application/global/config/SecurityConfig.kt
@@ -41,7 +41,8 @@ class SecurityConfig(
                     configuration.allowCredentials = true
                     configuration
                 }
-            }            .formLogin { it.disable() }
+            }
+            .formLogin { it.disable() }
             .sessionManagement {
                 it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             }
@@ -53,8 +54,8 @@ class SecurityConfig(
                     .requestMatchers("/swagger-resources/**").permitAll()
                     .requestMatchers("/webjars/**").permitAll()
                     .requestMatchers("/admin/**").hasRole(UserRole.ADMIN.name)
-                    .requestMatchers("/api/v1/applications/**").hasRole(UserRole.USER.name)
                     .requestMatchers(HttpMethod.GET, "/api/v1/**").hasRole(UserRole.ADMIN.name)
+                    .requestMatchers("/api/v1/applications/**").hasRole(UserRole.USER.name)
                     .requestMatchers("/photo").hasRole(UserRole.USER.name)
                     .anyRequest().authenticated()
             }


### PR DESCRIPTION
- ApplicationQueryController의 인증 권한 역할을 ADMIN으로 수정 후, ApplicationSubmissionController의 인증 권한에 의해서 덮히지 않도록 순서 조정